### PR TITLE
feat(socialEmbeds): add facebook embeds to the case page

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -67,6 +67,7 @@ module.exports = {
               "Events",
               "Persons_of_Interest",
               "Places",
+              "Social_Embeds",
               "Suspects",
               "Texts",
               "Victims",
@@ -94,6 +95,11 @@ module.exports = {
           {
             baseId: `appcAT8442e7faJRH`,
             tableName: `Places`,
+            tableLinks: ["Cases"],
+          },
+          {
+            baseId: `appcAT8442e7faJRH`,
+            tableName: `Social_Embeds`,
             tableLinks: ["Cases"],
           },
           {

--- a/src/components/social.js
+++ b/src/components/social.js
@@ -1,0 +1,41 @@
+/** @jsx jsx */
+import { Flex, jsx, Styled } from "theme-ui"
+
+const Social = ({ socialEmbeds }) => {
+  return (
+    <section sx={{ p: [16, 16, 24], textAlign: "center" }}>
+      <Styled.h2
+        sx={{
+          mb: 8,
+        }}
+      >
+        Social
+      </Styled.h2>
+      <Flex
+        sx={{
+          flexWrap: "wrap",
+          justifyContent: "center",
+        }}
+      >
+        {socialEmbeds.map(socialEmbed => {
+          const { height, source, width, url } = socialEmbed.data
+          return (
+            <iframe
+              allow="encrypted-media"
+              allowTransparency="true"
+              frameborder="0"
+              height={height}
+              scrolling="no"
+              src={url}
+              sx={{ border: "none", m: 16, overflow: "hidden" }}
+              title={source}
+              width={width}
+            ></iframe>
+          )
+        })}
+      </Flex>
+    </section>
+  )
+}
+
+export default Social

--- a/src/templates/case.jsx
+++ b/src/templates/case.jsx
@@ -11,6 +11,7 @@ import Layout from "components/layout"
 import Persons from "components/persons"
 import Places from "components/places"
 import Share from "components/share"
+import Social from "components/social"
 import Suspects from "components/suspects"
 import SEO from "components/seo"
 import Texts from "components/texts"
@@ -33,6 +34,7 @@ const CasesTemplate = ({ data }) => {
     instagramStoryImage,
     persons,
     places,
+    socialEmbeds,
     status,
     suspects,
     summary,
@@ -150,6 +152,8 @@ const CasesTemplate = ({ data }) => {
         {audio && <Audios audios={audio} />}
 
         {texts && <Texts texts={texts} />}
+
+        {socialEmbeds && <Social socialEmbeds={socialEmbeds} />}
 
         {facebookImage && (
           <Share
@@ -273,6 +277,14 @@ export const query = graphql`
                   latitude: Latitude
                   longitude: Longitude
                   title: Title
+                }
+              }
+              socialEmbeds: Social_Embeds {
+                data {
+                  height: Height
+                  source: Source
+                  url: URL
+                  width: Width
                 }
               }
               suspects: Suspects {


### PR DESCRIPTION
This uses Facebook only, since Twitter requires a `script`